### PR TITLE
Update url in gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/meghna-hugo"]
 	path = themes/meghna-hugo
-	url = git@github.com:qcooperative/meghna-hugo.git
+	url = https://github.com/qcooperative/meghna-hugo.git


### PR DESCRIPTION
Current action cannot pull submodules:

```
Run git submodule update --init
Submodule 'themes/meghna-hugo' (git@github.com:qcooperative/meghna-hugo.git) registered for path 'themes/meghna-hugo'
Cloning into '/home/runner/work/website/website/themes/meghna-hugo'...
Warning: Permanently added the RSA host key for IP address '140.82.114.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

It should be fixed by using `https` instead of `git` for the submodule's URL.