### PR TITLE
Leave existing files untouched

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,3 +26,5 @@ jobs:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: ./public
+      with:
+        keepFiles: true


### PR DESCRIPTION
Default behavior for `actions-gh-pages`: ` existing files in the publish branch are removed before adding the ones from publish dir/`.

It's an issue in our case because some important files are not generated by Hugo (like `CNAME` and others).